### PR TITLE
Fix an issue preventing the exit command from working on the server c…

### DIFF
--- a/src/Rasa.Game/Game/Server.cs
+++ b/src/Rasa.Game/Game/Server.cs
@@ -92,6 +92,8 @@ namespace Rasa.Game
 
         public void MainLoop(long delta)
         {
+            Timer.Update(delta);
+
             if (Clients.Count == 0)
                 return;
 


### PR DESCRIPTION
…onsole

The server mainloop was not calling the Timer.Update method thus preventing the timers from working correctly.
The exit command uses a timer internally to delay the server shutdown, as a result the server was never shutting down.