### PR TITLE
Developer specific configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,5 @@ $RECYCLE.BIN/
 /src/Rasa.Auth/log-auth.txt
 
 src/Rasa.Game/log-game.txt
+src/Rasa.Auth/appsettings.env.json
+src/Rasa.Game/appsettings.env.json

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -98,9 +98,15 @@ The auth and game servers are pre-configured to use the user `rasa` to connect. 
 You should be ready to compile Rasa.NET and run the servers. 
 
 - Launch Visual Studio and open the `Rasa.NET.sln` file in the code repository
+- If you have to overwrite the default connection strings from the appsettings.json, see "Custom configuration" down below
 - Build the solution
 - Run the `Rasa.Auth` project via `Debug > Start without Debugging`
 - Run the `Rasa.Game` project via `Debug > Start Debugging`
+- Alternatively, define multiple start projects as follows:
+-- Right click on the solution
+-- Click "Set StartUp Projects"
+-- Choose "Multiple startup projects"
+-- Set "Action" for both projects wether you want to start with or without debugging
 
 ### Create a game user
 The authentication server can be used to create a user by running a command in the terminal. The usage is: `create <email> <username> <password>`. Running this command will create a new user in the database that you can use to login with the game client.
@@ -108,6 +114,22 @@ The authentication server can be used to create a user by running a command in t
 - Run the command in the authentication termain. i.e. `create test@test.com test test`
   - You can use any username / password that you want to create an account.
 
+## Custom configuration
+If you have to overwrite one or multiple settings from the appsettings.json of `Rasa.Auth` or `Rasa.Game`, do the following:
+
+- Create a file named "appsettings.env.json" in the root of the respective project or copy and rename the existing appsettings.json
+- The new file will be shown as subelement of the original appsettings.json
+- Use the new file to overwrite settings from appsettings.json. Keep property naming and structure, you don't need to add settings that you don't want to change. For example, to overwrite GameConfig.PublicAddress in the Rasa.Game settings, use 
+- The "appsettings.env.json" is ignored in git. Keep it that way.
+
+```json
+{
+  "GameConfig":{
+    "PublicAddress": "<new value>"
+  }
+}
+```
+  
 ## Launch the game
 If the server consoles launched correctly, you should be ready to start the game client. 
 

--- a/src/Rasa.Auth/Rasa.Auth.csproj
+++ b/src/Rasa.Auth/Rasa.Auth.csproj
@@ -15,8 +15,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="appsettings.env.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.env.json" Condition="Exists('appsettings.env.json')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <DependentUpon>appsettings.json</DependentUpon>
     </None>
   </ItemGroup>
 

--- a/src/Rasa.Game/Rasa.Game.csproj
+++ b/src/Rasa.Game/Rasa.Game.csproj
@@ -24,6 +24,10 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.env.json" Condition="Exists('appsettings.env.json')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <DependentUpon>appsettings.json</DependentUpon>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added appsettings.env.json to project files and .gitignore to allow for easy configuration per developer, for example to change the database connection strings without interfering with on another.
Also added some hints to the setup.md regarding custom configuration.