### PR TITLE
Simplification of DbContext and provider specific property building

### DIFF
--- a/Rasa.NET.sln.DotSettings
+++ b/Rasa.NET.sln.DotSettings
@@ -95,6 +95,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rasa/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sqlite/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Teleport/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=teleporter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Waypoint/@EntryIndexedValue">True</s:Boolean>

--- a/src/Rasa.Auth/AuthProgram.cs
+++ b/src/Rasa.Auth/AuthProgram.cs
@@ -61,12 +61,10 @@ namespace Rasa
 
         private static void AddDatabase(HostBuilderContext context, IServiceCollection services)
         {
-
             var databaseConfigSection = context.Configuration
                 .GetSection("Databases");
-            services.Configure<DatabaseConfiguration>(databaseConfigSection);
 
-            var databaseProvider = services.AddDatabaseProviderSpecificBindings(databaseConfigSection.GetValue<string>("Provider"));
+            var databaseProvider = services.AddDatabaseProviderSpecificBindings(databaseConfigSection);
 
             switch (databaseProvider)
             {

--- a/src/Rasa.DBL/Configuration/DatabaseConfiguration.cs
+++ b/src/Rasa.DBL/Configuration/DatabaseConfiguration.cs
@@ -11,10 +11,10 @@ namespace Rasa.Configuration
 
         public DatabaseProvider GetDatabaseProvider()
         {
-            return ConvertProvider(Provider);
+            return ConvertDatabaseProvider(Provider);
         }
-        
-        public static DatabaseProvider ConvertProvider(string databaseProviderStr)
+
+        public static DatabaseProvider ConvertDatabaseProvider(string databaseProviderStr)
         {
             if (Enum.TryParse(databaseProviderStr, true, out DatabaseProvider databaseProvider))
             {

--- a/src/Rasa.DBL/Context/Auth/AuthContext.cs
+++ b/src/Rasa.DBL/Context/Auth/AuthContext.cs
@@ -5,45 +5,53 @@ namespace Rasa.Context.Auth
 {
     using Configuration;
     using Configuration.ContextSetup;
+    using Extensions;
     using Initialization;
+    using Services;
     using Structures;
 
     public abstract class AuthContext : DbContext, IInitializable
     {
         private readonly IOptions<DatabaseConfiguration> _databaseConfiguration;
         private readonly IDbContextConfigurationService _dbContextConfigurationService;
+        private readonly IDbContextPropertyModifier _dbContextPropertyModifier;
 
-        /// <summary>
-        /// Constructor for DI
-        /// </summary>
         protected AuthContext(IOptions<DatabaseConfiguration> databaseConfiguration, 
-            IDbContextConfigurationService dbContextConfigurationService)
+            IDbContextConfigurationService dbContextConfigurationService,
+            IDbContextPropertyModifier dbContextPropertyModifier)
         {
             _databaseConfiguration = databaseConfiguration;
             _dbContextConfigurationService = dbContextConfigurationService;
-        }
-
-        /// <summary>
-        /// Constructor for migration tools
-        /// </summary>
-        internal AuthContext(DbContextOptions options) : base(options)
-        {
+            _dbContextPropertyModifier = dbContextPropertyModifier;
         }
 
         public DbSet<AuthAccountEntry> AuthAccountEntries { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            if (optionsBuilder.IsConfigured)
-            {
-                return;
-            }
-
             _dbContextConfigurationService.Configure(optionsBuilder, _databaseConfiguration.Value.Auth);
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<AuthAccountEntry>()
+                .Property(e => e.Id)
+                .AsIdColumn(_dbContextPropertyModifier);
+
+            modelBuilder.Entity<AuthAccountEntry>()
+                .Property(e => e.Level)
+                .AsTinyInt(_dbContextPropertyModifier, 3)
+                .HasDefaultValue(0);
+
+            modelBuilder.Entity<AuthAccountEntry>()
+                .Property(e => e.LastServerId)
+                .AsTinyInt(_dbContextPropertyModifier, 3)
+                .HasDefaultValue(0);
+
+            modelBuilder.Entity<AuthAccountEntry>()
+                .Property(e => e.JoinDate)
+                .AsCurrentDateTime(_dbContextPropertyModifier);
+
             modelBuilder.Entity<AuthAccountEntry>()
                 .Property(e => e.LastIp)
                 .HasDefaultValue("0.0.0.0");

--- a/src/Rasa.DBL/Context/Auth/DesignTimeMySqlAuthContextFactory.cs
+++ b/src/Rasa.DBL/Context/Auth/DesignTimeMySqlAuthContextFactory.cs
@@ -4,6 +4,8 @@ using JetBrains.Annotations;
 
 namespace Rasa.Context.Auth
 {
+    using Configuration;
+
     /// <summary>
     /// Used by EF Core to create and execute migrations.
     /// </summary>
@@ -12,7 +14,7 @@ namespace Rasa.Context.Auth
     {
         public MySqlAuthContext CreateDbContext(string[] args)
         {
-            return CreateDbContext<MySqlAuthContext>();
+            return CreateDbContext<MySqlAuthContext>(DatabaseProvider.MySql);
         }
     }
 }

--- a/src/Rasa.DBL/Context/Auth/DesignTimeMySqlAuthContextFactory.cs
+++ b/src/Rasa.DBL/Context/Auth/DesignTimeMySqlAuthContextFactory.cs
@@ -1,16 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore.Design;
 
+using JetBrains.Annotations;
+
 namespace Rasa.Context.Auth
 {
-    using Configuration;
-
+    /// <summary>
+    /// Used by EF Core to create and execute migrations.
+    /// </summary>
+    [UsedImplicitly]
     public class DesignTimeMySqlAuthContextFactory : DesignTimeContextFactoryBase, IDesignTimeDbContextFactory<MySqlAuthContext>
     {
         public MySqlAuthContext CreateDbContext(string[] args)
         {
-            var options = CreateDbContextOptions("Auth", DatabaseProvider.MySql);
-
-            return new MySqlAuthContext(options);
+            return CreateDbContext<MySqlAuthContext>();
         }
     }
 }

--- a/src/Rasa.DBL/Context/Auth/DesignTimeSqliteAuthContextFactory.cs
+++ b/src/Rasa.DBL/Context/Auth/DesignTimeSqliteAuthContextFactory.cs
@@ -1,16 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore.Design;
 
+using JetBrains.Annotations;
+
 namespace Rasa.Context.Auth
 {
-    using Configuration;
-
+    /// <summary>
+    /// Used by EF Core to create and execute migrations.
+    /// </summary>
+    [UsedImplicitly]
     public class DesignTimeSqliteAuthContextFactory : DesignTimeContextFactoryBase, IDesignTimeDbContextFactory<SqliteAuthContext>
     {
         public SqliteAuthContext CreateDbContext(string[] args)
         {
-            var options = CreateDbContextOptions("Auth", DatabaseProvider.Sqlite);
-
-            return new SqliteAuthContext(options);
+            return CreateDbContext<SqliteAuthContext>();
         }
     }
 }

--- a/src/Rasa.DBL/Context/Auth/DesignTimeSqliteAuthContextFactory.cs
+++ b/src/Rasa.DBL/Context/Auth/DesignTimeSqliteAuthContextFactory.cs
@@ -4,6 +4,8 @@ using JetBrains.Annotations;
 
 namespace Rasa.Context.Auth
 {
+    using Configuration;
+
     /// <summary>
     /// Used by EF Core to create and execute migrations.
     /// </summary>
@@ -12,7 +14,7 @@ namespace Rasa.Context.Auth
     {
         public SqliteAuthContext CreateDbContext(string[] args)
         {
-            return CreateDbContext<SqliteAuthContext>();
+            return CreateDbContext<SqliteAuthContext>(DatabaseProvider.Sqlite);
         }
     }
 }

--- a/src/Rasa.DBL/Context/Auth/MySqlAuthContext.cs
+++ b/src/Rasa.DBL/Context/Auth/MySqlAuthContext.cs
@@ -5,41 +5,16 @@ namespace Rasa.Context.Auth
 {
     using Configuration;
     using Configuration.ContextSetup;
+    using Services;
     using Structures;
 
     public class MySqlAuthContext : AuthContext
     {
         public MySqlAuthContext(IOptions<DatabaseConfiguration> databaseConfiguration, 
-            IDbContextConfigurationService dbContextConfigurationService) 
-            : base(databaseConfiguration, dbContextConfigurationService)
+            IDbContextConfigurationService dbContextConfigurationService,
+            IDbContextPropertyModifier dbContextPropertyModifier ) 
+            : base(databaseConfiguration, dbContextConfigurationService, dbContextPropertyModifier)
         {
-        }
-
-        internal MySqlAuthContext(DbContextOptions options) : base(options)
-        {
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.Id)
-                .HasColumnType("int(11) unsigned");
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.Level)
-                .HasColumnType("tinyint(3) unsigned")
-                .HasDefaultValue(0);
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.LastServerId)
-                .HasColumnType("tinyint(3) unsigned")
-                .HasDefaultValue(0);
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.JoinDate)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP");
         }
     }
 }

--- a/src/Rasa.DBL/Context/Auth/SqliteAuthContext.cs
+++ b/src/Rasa.DBL/Context/Auth/SqliteAuthContext.cs
@@ -1,45 +1,18 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 
 namespace Rasa.Context.Auth
 {
     using Configuration;
     using Configuration.ContextSetup;
-    using Structures;
+    using Services;
 
     public class SqliteAuthContext : AuthContext
     {
         public SqliteAuthContext(IOptions<DatabaseConfiguration> databaseConfiguration, 
-            IDbContextConfigurationService dbContextConfigurationService) 
-            : base(databaseConfiguration, dbContextConfigurationService)
+            IDbContextConfigurationService dbContextConfigurationService,
+            IDbContextPropertyModifier dbContextPropertyModifier)
+            : base(databaseConfiguration, dbContextConfigurationService, dbContextPropertyModifier)
         {
-        }
-
-        internal SqliteAuthContext(DbContextOptions options) : base(options)
-        {
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.Id)
-                .HasColumnType("integer");
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.Level)
-                .HasColumnType("tinyint(3)")
-                .HasDefaultValue(0);
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.LastServerId)
-                .HasColumnType("tinyint(3)")
-                .HasDefaultValue(0);
-
-            modelBuilder.Entity<AuthAccountEntry>()
-                .Property(e => e.JoinDate)
-                .HasDefaultValueSql("datetime('now')");
         }
     }
 }

--- a/src/Rasa.DBL/Context/DesignTimeContextFactoryBase.cs
+++ b/src/Rasa.DBL/Context/DesignTimeContextFactoryBase.cs
@@ -5,13 +5,14 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Rasa.Context
 {
     using Binding;
+    using Configuration;
 
     public abstract class DesignTimeContextFactoryBase
     {
-        protected static T CreateDbContext<T>()
+        protected static T CreateDbContext<T>(DatabaseProvider overwriteDatabaseProvider)
             where T : DbContext
         {
-            var databaseSection = LoadConfiguration<T>();
+            var databaseSection = LoadConfiguration(overwriteDatabaseProvider);
 
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddDatabaseProviderSpecificBindings(databaseSection);
@@ -20,7 +21,7 @@ namespace Rasa.Context
             return serviceCollection.BuildServiceProvider().GetService<T>();
         }
 
-        private static IConfigurationSection LoadConfiguration<T>() where T : DbContext
+        private static IConfigurationSection LoadConfiguration(DatabaseProvider overwriteDatabaseProvider)
         {
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile("databasesettings.json", false, false)
@@ -29,6 +30,9 @@ namespace Rasa.Context
 
             var databaseSection = configuration
                 .GetSection("Databases");
+
+            databaseSection[nameof(DatabaseConfiguration.Provider)] = overwriteDatabaseProvider.ToString();
+
             return databaseSection;
         }
     }

--- a/src/Rasa.DBL/Extensions/PropertyBuilderExtensions.cs
+++ b/src/Rasa.DBL/Extensions/PropertyBuilderExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Rasa.Extensions
+{
+    using Services;
+
+    public static class PropertyBuilderExtensions
+    {
+        public static PropertyBuilder<T> AsIdColumn<T>(this PropertyBuilder<T> builder, IDbContextPropertyModifier modifier)
+        {
+            return modifier.AsIdColumn(builder);
+        }
+
+        public static PropertyBuilder<T> AsCurrentDateTime<T>(this PropertyBuilder<T> builder, IDbContextPropertyModifier modifier)
+        {
+            return modifier.AsCurrentDateTime(builder);
+        }
+
+        public static PropertyBuilder<T> AsTinyInt<T>(this PropertyBuilder<T> builder, IDbContextPropertyModifier modifier, int length)
+        {
+            return modifier.AsTinyInt(builder, length);
+        }
+    }
+}

--- a/src/Rasa.DBL/Rasa.DBL.csproj
+++ b/src/Rasa.DBL/Rasa.DBL.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="10.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Rasa.DBL/Services/IDbContextPropertyModifier.cs
+++ b/src/Rasa.DBL/Services/IDbContextPropertyModifier.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Rasa.Services
+{
+    public interface IDbContextPropertyModifier
+    {
+        PropertyBuilder<T> AsIdColumn<T>(PropertyBuilder<T> builder);
+
+        PropertyBuilder<T> AsCurrentDateTime<T>(PropertyBuilder<T> builder);
+
+        PropertyBuilder<T> AsTinyInt<T>(PropertyBuilder<T> builder, int length);
+    }
+}

--- a/src/Rasa.DBL/Services/MySqlDbContextPropertyModifier.cs
+++ b/src/Rasa.DBL/Services/MySqlDbContextPropertyModifier.cs
@@ -1,0 +1,23 @@
+﻿namespace Rasa.Services
+{
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+    public class MySqlDbContextPropertyModifier : IDbContextPropertyModifier
+    {
+        public PropertyBuilder<T> AsIdColumn<T>(PropertyBuilder<T> builder)
+        {
+            return builder.HasColumnType("int(11) unsigned");
+        }
+
+        public PropertyBuilder<T> AsTinyInt<T>(PropertyBuilder<T> builder, int length)
+        {
+            return builder.HasColumnType($"tinyint({length}) unsigned");
+        }
+
+        public PropertyBuilder<T> AsCurrentDateTime<T>(PropertyBuilder<T> builder)
+        {
+            return builder.HasDefaultValueSql("CURRENT_TIMESTAMP");
+        }
+    }
+}

--- a/src/Rasa.DBL/Services/SqliteDbContextPropertyModifier.cs
+++ b/src/Rasa.DBL/Services/SqliteDbContextPropertyModifier.cs
@@ -17,7 +17,7 @@
 
         public PropertyBuilder<T> AsCurrentDateTime<T>(PropertyBuilder<T> builder)
         {
-            return builder.HasDefaultValueSql("date('now')");
+            return builder.HasDefaultValueSql("datetime('now')");
         }
     }
 }

--- a/src/Rasa.DBL/Services/SqliteDbContextPropertyModifier.cs
+++ b/src/Rasa.DBL/Services/SqliteDbContextPropertyModifier.cs
@@ -1,0 +1,23 @@
+﻿namespace Rasa.Services
+{
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+    public class SqliteDbContextPropertyModifier : IDbContextPropertyModifier
+    {
+        public PropertyBuilder<T> AsIdColumn<T>(PropertyBuilder<T> builder)
+        {
+            return builder.HasColumnType("integer");
+        }
+
+        public PropertyBuilder<T> AsTinyInt<T>(PropertyBuilder<T> builder, int length)
+        {
+            return builder.HasColumnType($"tinyint({length})");
+        }
+
+        public PropertyBuilder<T> AsCurrentDateTime<T>(PropertyBuilder<T> builder)
+        {
+            return builder.HasDefaultValueSql("date('now')");
+        }
+    }
+}

--- a/src/Rasa.DBL/Structures/AuthAccountEntry.cs
+++ b/src/Rasa.DBL/Structures/AuthAccountEntry.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 


### PR DESCRIPTION
* removed internal constructors from DbContexts, instead using the default constructor that is used by DI
** therefore changed DesignTime factories to use default database dependency binding
** database dependency binding now binds everything but the contexts
* encapsulated required database specific PropertyBuilder functionality into classes to streamline modeling instead of doing model changes in the database specific contexts