### PR TITLE
Add support for docker launch of servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0
+
+WORKDIR /app
+
+COPY src /app/src
+COPY Rasa.NET.sln /app
+COPY Rasa.NET.sln.DotSettings /app
+
+RUN dotnet restore
+RUN dotnet build --no-restore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  auth:
+    image: rasa_net
+    restart: always
+    build: .
+    command: dotnet run --project src/Rasa.Auth/Rasa.Auth.csproj
+    stdin_open: true
+    tty: true
+    ports:
+      - "2106:2106"
+      - "2107:2107"
+    volumes:
+      - ./rasaauth.db:/app/rasaauth.db
+  game:
+    image: rasa_net
+    restart: always
+    build: .
+    command: dotnet run --project src/Rasa.Game/Rasa.Game.csproj
+    stdin_open: true
+    tty: true
+    ports:
+      - "8102:8102"
+      - "8001:8001"
+    volumes:
+      - ./rasachar.db:/app/rasachar.db
+      - ./rasaworld.db:/app/rasaworld.db
+      - ./appsettings.env.json:/app/src/Rasa.Game/appsettings.env.json
+

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -1,0 +1,40 @@
+# Docker Setup Guide
+
+This was tested using Linux. This provides an alternative to building and using the project directly on your system.
+
+## Clone the Repo
+
+First, clone the git repository like normal, Then make sure to go into the directory.
+
+## Touch DB Files
+
+This step is needed to provide empty database files to mount for the first launch, due to the way docker mounts handle missing files. This will only need to be done once before starting fresh.
+
+```bash
+touch rasaauth.db
+touch rasachar.db
+touch rasaworld.db
+```
+
+## Create App Settings
+
+Next, create a appsettings.env.json in the root directory with the following contents, replacing the ip address with the one that is running the docker containers. This is useful especially when the system you're running the game on is different from where the containers are running.
+
+```json
+{
+  "CommunicatorConfig": {
+    "Address": "192.168.0.26"
+  },
+  "GameConfig": {
+    "PublicAddress": "192.168.0.26"
+  }
+}
+```
+
+## Create a User
+
+Like the setup docs mention, the next step is creating a user. To do so, attach to the auth server and run the command.
+
+## Play the Game
+
+Now, you should be able to run `tabula_rasa.exe /NoPatch /AuthServer=192.168.0.26:2106` and login.

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -31,6 +31,10 @@ Next, create a appsettings.env.json in the root directory with the following con
 }
 ```
 
+## Start Server
+
+Next, run `docker compose up`
+
 ## Create a User
 
 Like the setup docs mention, the next step is creating a user. To do so, attach to the auth server and run the command.

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -2,6 +2,8 @@
 
 This was tested using Linux. This provides an alternative to building and using the project directly on your system.
 
+This currently only supports SQLite for the database.
+
 ## Clone the Repo
 
 First, clone the git repository like normal, Then make sure to go into the directory.


### PR DESCRIPTION
This adds an optional way of running the project using docker compose. Currently, it uses the sqlite database version, but a future version could be setup to use mysql instead.

I was able to successfully use this to start the server on a different system and then launch tabula rasa and get in-game.