### PR TITLE
Server Console Interaction Improvements

### DIFF
--- a/src/Rasa.Utils/Commands/CommandProcessor.cs
+++ b/src/Rasa.Utils/Commands/CommandProcessor.cs
@@ -42,6 +42,7 @@ namespace Rasa.Commands
                             return command;
                         case ConsoleKey.Backspace:
                             command = command.Substring(0, command.Length - 1);
+                            Console.Write("\b \b");
                             break;
                         default:
                             command += key.KeyChar;

--- a/src/Rasa.Utils/Commands/CommandProcessor.cs
+++ b/src/Rasa.Utils/Commands/CommandProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Rasa.Commands
 {
@@ -8,9 +9,9 @@ namespace Rasa.Commands
     {
         private static readonly Dictionary<string, Action<string[]>> Commands = new Dictionary<string, Action<string[]>>();
 
-        public static void ProcessCommand(CancellationToken stopToken)
+        public static async Task ProcessCommand(CancellationToken stopToken)
         {
-            var command = ReadCommand(stopToken);
+            var command = await ReadCommand(stopToken);
             if (string.IsNullOrWhiteSpace(command))
                 return;
 
@@ -27,7 +28,7 @@ namespace Rasa.Commands
             Logger.WriteLog(LogType.Command, $"Invalid command: {command}");
         }
 
-        private static string ReadCommand(CancellationToken stopToken)
+        private static async Task<string> ReadCommand(CancellationToken stopToken)
         {
             var command = string.Empty;
             while (!stopToken.IsCancellationRequested)
@@ -47,6 +48,8 @@ namespace Rasa.Commands
                             break;
                     }
                 }
+
+                await Task.Delay(25, stopToken);
             }
             return null;
         }

--- a/src/Rasa.Utils/Hosting/RasaHost.cs
+++ b/src/Rasa.Utils/Hosting/RasaHost.cs
@@ -50,7 +50,7 @@ namespace Rasa.Hosting
 
             while (_rasaServer.Running && !stoppingToken.IsCancellationRequested)
             {
-                CommandProcessor.ProcessCommand(stoppingToken);
+                await CommandProcessor.ProcessCommand(stoppingToken);
                 await Task.Delay(25, stoppingToken);
             }
         }


### PR DESCRIPTION
I noticed when running the server on Linux that the CPU usage was pretty high (staying at about 100%), and I could hear the fans going pretty fast.

This was due to the `ReadCommand` method having a while loop that didn't sleep, so when it was waiting for character input, it took up all the CPU time doing so. I added a Task.Delay, modeling that after the way the outer loop works, to delay for a bit to avoid this.

As well, I noticed that the console display didn't update when you hit backspace, so I added some code to update the display as well.

With these changes, the CPU time for the auth and game processes are much more reasonable.