### PR TITLE
Github Action Updates

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 5.0.x
     - name: Restore dependencies

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,8 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, development ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
This updates the github action currently there to run on development branch, as well as any pull request that comes in (instead of it being set to a branch). This will mean that on any new pull request, the action will run to build and run tests. New contributors will require approval from you all for it to run the first time.

The second part involves updating the actions in use to newer versions, to avoid issues with the older versions.